### PR TITLE
Don't need pastebindecoder anymore.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ djangorestframework
 psycopg2-binary
 gunicorn
 python-magic
--e git+https://github.com/g-clef/PastebinDecoder#egg=PastebinDecoder


### PR DESCRIPTION
 it's in the analyzer, so remove it from requirements.